### PR TITLE
remove duplications between dimensions with and without values

### DIFF
--- a/abstract.go
+++ b/abstract.go
@@ -191,6 +191,9 @@ func scrapeDiscoveryJobUsingMetricData(
 			// Adds the dimensions with values of that specific metric of the job
 			dimensionsWithValue = addAdditionalDimensions(dimensionsWithValue, metric.AdditionalDimensions)
 
+			// Filter the commonJob Dimensions by the discovered/added dimensions as duplicates cause no metrics to be discovered
+			commonJobDimensions = filterDimensionsWithoutValueByDimensionsWithValue(commonJobDimensions, dimensionsWithValue)
+
 			metricsToAdd := filterMetricsBasedOnDimensionsWithValues(dimensionsWithValue, commonJobDimensions, fullMetricsList)
 
 			if metricsToAdd != nil {

--- a/aws_cloudwatch.go
+++ b/aws_cloudwatch.go
@@ -346,6 +346,18 @@ func filterMetricsBasedOnDimensions(dimensions []*cloudwatch.Dimension, resp *cl
 	return &output
 }
 
+func filterDimensionsWithoutValueByDimensionsWithValue(
+    dimensionsWithoutValue []*cloudwatch.Dimension,
+    dimensionsWithValue []*cloudwatch.Dimension) (dimensions []*cloudwatch.Dimension) {
+
+    for _, dimension := range dimensionsWithoutValue {
+        if ! dimensionIsInListWithoutValues(dimension, dimensionsWithValue) {
+            dimensions = append(dimensions, dimension)
+        }
+    }
+    return dimensions
+}
+
 func getAwsDimensions(job job) (dimensions []*cloudwatch.Dimension) {
 	for _, awsDimension := range job.AwsDimensions {
 		dimensions = append(dimensions, buildDimensionWithoutValue(awsDimension))


### PR DESCRIPTION
A duplication of the settings between awsDimensions on a job and the discovered base dimensions for the cloudwatch namespace will cause no metrics to be discovered. This adds a filter that will remove those duplicates from that list automatically and reduce the possibility for error in the configuration.