### PR TITLE
add snake case switch

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ var (
 	scrapingInterval      = flag.Int("scraping-interval", 300, "Seconds to wait between scraping the AWS metrics if decoupled scraping.")
 	decoupledScraping     = flag.Bool("decoupled-scraping", true, "Decouples scraping and serving of metrics.")
 	metricsPerQuery       = flag.Int("metrics-per-query", 500, "Number of metrics made in a single GetMetricsData request")
+	labelsSnakeCase       = flag.Bool("labels-snake-case", false, "If labels should be output in snake case instead of camel case")
 
 	supportedServices = []string{
 		"alb",

--- a/prometheus.go
+++ b/prometheus.go
@@ -119,6 +119,9 @@ func promString(text string) string {
 }
 
 func promStringTag(text string) string {
+    if *labelsSnakeCase {
+        return promString(text)
+    }
 	return replaceWithUnderscores(text)
 }
 


### PR DESCRIPTION
To increase "drop in" compatibility with other exporters available currently we need to be able to output labels on the metrics in snake case as opposed to the default camel case. This PR adds a command line switch for that mode.