### PR TITLE
setting inheritance

### DIFF
--- a/config.go
+++ b/config.go
@@ -21,14 +21,16 @@ type discovery struct {
 type exportedTagsOnMetrics map[string][]string
 
 type job struct {
-	Regions       []string `yaml:"regions"`
-	Type          string   `yaml:"type"`
-	RoleArn       string   `yaml:"roleArn"`
-	AwsDimensions []string `yaml:"awsDimensions"`
-	SearchTags    []tag    `yaml:"searchTags"`
-	Metrics       []metric `yaml:"metrics"`
-	Length        int      `yaml:"length"`
-	Delay         int      `yaml:"delay"`
+	Regions                 []string `yaml:"regions"`
+	Type                    string   `yaml:"type"`
+	RoleArn                 string   `yaml:"roleArn"`
+	AwsDimensions           []string `yaml:"awsDimensions"`
+	SearchTags              []tag    `yaml:"searchTags"`
+	Metrics                 []metric `yaml:"metrics"`
+	Length                  int      `yaml:"length"`
+	Delay                   int      `yaml:"delay"`
+	Period                  int      `yaml:"period"`
+	AddCloudwatchTimestamp  bool     `yaml:"addCloudwatchTimestamp"`
 }
 
 type static struct {
@@ -81,7 +83,7 @@ func (c *conf) load(file *string) error {
 				log.Warn("WATCH OUT! - Metric length of less than 5 minutes configured which is default for most cloudwatch metrics e.g. ELBs")
 			}
 
-			if metric.Period < 1 {
+			if job.Period < 1 && metric.Period < 1 {
 				return fmt.Errorf("Period value should be a positive integer")
 			}
 		}

--- a/config.go
+++ b/config.go
@@ -77,7 +77,7 @@ func (c *conf) load(file *string) error {
 		}
 
 		for _, metric := range job.Metrics {
-			if metric.Length < 300 {
+			if job.Length < 300 && metric.Length < 300 {
 				log.Warn("WATCH OUT! - Metric length of less than 5 minutes configured which is default for most cloudwatch metrics e.g. ELBs")
 			}
 


### PR DESCRIPTION
For commonly repeated metric config elements we can use a setting at the job level that can be overriden by a setting lower down at the metric level. This adds that ability for:

- period
- addCloudwatchTimestamp